### PR TITLE
CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @GMouron @seguins


### PR DESCRIPTION
On assigne tous les repos à une BU ou à une guilde. Les repos de guilde doivent avoir un fichier CODEOWNERS

Si l'assignation des CODEOWNERS ne vous convient pas, vous êtes libres de proposer d'autres personnes.